### PR TITLE
Std.List.prj_exn to normal GT.list

### DIFF
--- a/src/std/List.ml
+++ b/src/std/List.ml
@@ -115,6 +115,17 @@ let rec prj_exn : ('a, 'b) Reifier.t -> ('a groundi, 'b ground) Reifier.t =
       let* fr = rself in
       Env.Monad.return (fun x -> GT.gmap t fa fr x)))
 
+let prj_to_list_exn : ('a, 'b) Reifier.t -> ('a groundi, 'b GT.list) Reifier.t =
+  let gmap fa fb = function
+    | Nil -> Stdlib.List.([])
+    | Cons (h, tl) -> Stdlib.List.cons (fa h) (fb tl)
+  in
+  let open Env.Monad in
+  let fmapt fa fb subj = return gmap <*> fa <*> fb <*> subj in
+  fun ra ->
+    let open Env.Monad.Syntax in
+    Reifier.fix (fun self -> Logic.Reifier.prj_exn <..> chain (fmapt ra self))
+
 let rec prj : (int -> _ ground) -> ('a, 'b) Reifier.t -> ('a groundi, 'b ground) Reifier.t =
   fun onvar ra ->
     let ( >>= ) = Env.Monad.bind in

--- a/src/std/List.mli
+++ b/src/std/List.mli
@@ -92,6 +92,8 @@ val reify :  ('a, 'b) Reifier.t -> ('a groundi, 'b logic) Reifier.t
 
 val prj_exn : ('a, 'b) Reifier.t -> ('a groundi, 'b ground) Reifier.t
 
+val prj_to_list_exn :  ('a, 'b) Reifier.t -> ('a groundi, 'b GT.list) Reifier.t
+
 val prj : (int -> 'b ground) -> ('a, 'b) Reifier.t -> ('a groundi, 'b ground) Reifier.t
 
 (** {3 Built-in relations} *)


### PR DESCRIPTION
Adds projection of `Std.List.logic` to standard `Stdlib.list`. It allows to get rid of the further conversion of `Std.List.ground` to `List.t`

During design of monadic reifiers, we discussed a new feature of reifying/projection to user-defined type. It seems that it may be a case, when it could be useful.

 Maybe, we can get rid of type `Std.List.ground` at all...

